### PR TITLE
Update env in eslint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,12 +4,11 @@ module.exports = {
 	plugins: ['svelte3'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	parserOptions: {
-		sourceType: 'module',
-		ecmaVersion: 2019
+		sourceType: 'module'
 	},
 	env: {
 		browser: true,
-		es2017: true,
+		es2020: true,
 		node: true
 	}
 };


### PR DESCRIPTION
Optional chaining is used in multiple places in the repo (svelte.config.js, runPandoc.js) but the parser was set to es2019.
Removed the ecmaVersion from parser because it is automatically set by env.

https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments
> es2020 - adds all ECMAScript 2020 globals and automatically sets the ecmaVersion parser option to 11.